### PR TITLE
fix(ci,makefile): add a new `release` Makefile target to pass LDFLAGS to goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release
-        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b #4.2.0
-        with:
-          version: latest
-          args: release --clean --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make release  

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,10 +5,7 @@ before:
   - go mod tidy
 
 builds:
-- env:
-  - CGO_ENABLED=0
-  - GO111MODULE=on
-  - GOEXPERIMENT=loopvar
+- id: "dbg-go"
   goos:
   - linux
   goarch:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO ?= go
+GORELEASER ?= goreleaser
 output ?= dbg-go
 TEST_FLAGS ?= -v -race -tags=test_all
 DRIVERKIT_VERSION=v0.15.0
@@ -19,6 +20,10 @@ clean:
 test:
 	GOEXPERIMENT=loopvar $(GO) test ${TEST_FLAGS} ./...
 
+.PHONY: release
+release: clean
+	CGO_ENABLED=0 GOEXPERIMENT=loopvar LDFLAGS="${LDFLAGS}" $(GORELEASER) release
+	
 .PHONY: bump-driverkit
 bump-driverkit:
 	go get github.com/falcosecurity/driverkit@$(DRIVERKIT_VER)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

We were not passing LDFLAGS to goreleaser, so driverkit "latest" builder images were being used.
Added a new Makefile `release` target that passes LDFLAGS to goreleaser.
I avoided using `ldflags` goreleaser config key because i wanted a single place where driverkit version was declared, to easily bump it (through `bump-driverkit` makefile target).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
