### PR TITLE
chore(ci): set ldflags for goreleaser from env.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,8 @@ builds:
   goarch:
   - amd64
   - arm64
+  ldflags:
+  - "{{.Env.LDFLAGS}}"
   binary: dbg-go
 
 checksum:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Properly enforce goreleaser flag from env `LDFLAGS` (passed from `make release`). This is the same thing we do in [Driverkit](https://github.com/falcosecurity/driverkit/blob/master/.goreleaser.yml#L15C5-L16C27)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
