### PR TITLE
chore(pkg/generate): properly sort kernelurls before dumping them.

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -55,7 +55,7 @@ func TestBuild(t *testing.T) {
 					RepoRoot:      "./test",
 					Target: root.Target{
 						Distro:        "centos",
-						KernelRelease: "5.14.0-368.el9.x86_64",
+						KernelRelease: "5.14.0-370.el9.x86_64",
 						KernelVersion: "1",
 					},
 				},
@@ -64,44 +64,14 @@ func TestBuild(t *testing.T) {
 				IgnoreErrors: false,
 			},
 			expectedLocalObjects: []string{
-				"falco_centos_5.14.0-368.el9.x86_64_1.ko",
-				"falco_centos_5.14.0-368.el9.x86_64_1.o",
-			},
-			expectedBucketObjects: []string{
-				"falco_centos_5.14.0-368.el9.x86_64_1.ko",
-				"falco_centos_5.14.0-368.el9.x86_64_1.o",
-			},
-			shouldCreate: true,
-			name:         "build 5.0.1+driver centos 5.14.0-368.el9.x86_64",
-		},
-		{
-			opts: Options{
-				Options: root.Options{
-					Architecture:  "amd64",
-					DriverVersion: []string{"5.0.1+driver"},
-					DriverName:    "falco",
-					RepoRoot:      "./test",
-					Target: root.Target{
-						Distro:        "centos",
-						KernelRelease: "5.14.0-370.el9.x86_64",
-						KernelVersion: "1",
-					},
-				},
-				SkipExisting: true,
-				Publish:      false,
-				IgnoreErrors: false,
-			},
-			expectedLocalObjects: []string{
 				"falco_centos_5.14.0-370.el9.x86_64_1.ko",
 				"falco_centos_5.14.0-370.el9.x86_64_1.o",
-				"falco_centos_5.14.0-368.el9.x86_64_1.ko",
-				"falco_centos_5.14.0-368.el9.x86_64_1.o",
 			},
 			expectedBucketObjects: []string{
-				"falco_centos_5.14.0-368.el9.x86_64_1.ko",
-				"falco_centos_5.14.0-368.el9.x86_64_1.o",
+				"falco_centos_5.14.0-370.el9.x86_64_1.ko",
+				"falco_centos_5.14.0-370.el9.x86_64_1.o",
 			},
-			shouldCreate: false, // since it is not publishing
+			shouldCreate: true,
 			name:         "build 5.0.1+driver centos 5.14.0-370.el9.x86_64",
 		},
 		{
@@ -113,26 +83,26 @@ func TestBuild(t *testing.T) {
 					RepoRoot:      "./test",
 					Target: root.Target{
 						Distro:        "centos",
-						KernelRelease: "5.14.0-368.el9.x86_64", // try to rebuild same object.
+						KernelRelease: "5.14.0-372.el9.x86_64",
 						KernelVersion: "1",
 					},
 				},
 				SkipExisting: true,
-				Publish:      true,
+				Publish:      false,
 				IgnoreErrors: false,
 			},
 			expectedLocalObjects: []string{
+				"falco_centos_5.14.0-372.el9.x86_64_1.ko",
+				"falco_centos_5.14.0-372.el9.x86_64_1.o",
 				"falco_centos_5.14.0-370.el9.x86_64_1.ko",
 				"falco_centos_5.14.0-370.el9.x86_64_1.o",
-				"falco_centos_5.14.0-368.el9.x86_64_1.ko",
-				"falco_centos_5.14.0-368.el9.x86_64_1.o",
 			},
 			expectedBucketObjects: []string{
-				"falco_centos_5.14.0-368.el9.x86_64_1.ko",
-				"falco_centos_5.14.0-368.el9.x86_64_1.o",
+				"falco_centos_5.14.0-370.el9.x86_64_1.ko",
+				"falco_centos_5.14.0-370.el9.x86_64_1.o",
 			},
-			shouldCreate: false, // since objects are already present, nothing should be created
-			name:         "rebuild 5.0.1+driver centos 5.14.0-368.el9.x86_64",
+			shouldCreate: false, // since it is not publishing
+			name:         "build 5.0.1+driver centos 5.14.0-372.el9.x86_64",
 		},
 		{
 			opts: Options{
@@ -143,7 +113,37 @@ func TestBuild(t *testing.T) {
 					RepoRoot:      "./test",
 					Target: root.Target{
 						Distro:        "centos",
-						KernelRelease: "5.14.0-368.el9.x86_64", // try to rebuild same object.
+						KernelRelease: "5.14.0-370.el9.x86_64", // try to rebuild same object.
+						KernelVersion: "1",
+					},
+				},
+				SkipExisting: true,
+				Publish:      true,
+				IgnoreErrors: false,
+			},
+			expectedLocalObjects: []string{
+				"falco_centos_5.14.0-372.el9.x86_64_1.ko",
+				"falco_centos_5.14.0-372.el9.x86_64_1.o",
+				"falco_centos_5.14.0-370.el9.x86_64_1.ko",
+				"falco_centos_5.14.0-370.el9.x86_64_1.o",
+			},
+			expectedBucketObjects: []string{
+				"falco_centos_5.14.0-370.el9.x86_64_1.ko",
+				"falco_centos_5.14.0-370.el9.x86_64_1.o",
+			},
+			shouldCreate: false, // since objects are already present, nothing should be created
+			name:         "rebuild 5.0.1+driver centos 5.14.0-370.el9.x86_64",
+		},
+		{
+			opts: Options{
+				Options: root.Options{
+					Architecture:  "amd64",
+					DriverVersion: []string{"5.0.1+driver"},
+					DriverName:    "falco",
+					RepoRoot:      "./test",
+					Target: root.Target{
+						Distro:        "centos",
+						KernelRelease: "5.14.0-370.el9.x86_64", // try to rebuild same object.
 						KernelVersion: "1",
 					},
 				},
@@ -152,17 +152,17 @@ func TestBuild(t *testing.T) {
 				IgnoreErrors: false,
 			},
 			expectedLocalObjects: []string{
+				"falco_centos_5.14.0-372.el9.x86_64_1.ko",
+				"falco_centos_5.14.0-372.el9.x86_64_1.o",
 				"falco_centos_5.14.0-370.el9.x86_64_1.ko",
 				"falco_centos_5.14.0-370.el9.x86_64_1.o",
-				"falco_centos_5.14.0-368.el9.x86_64_1.ko",
-				"falco_centos_5.14.0-368.el9.x86_64_1.o",
 			},
 			expectedBucketObjects: []string{
-				"falco_centos_5.14.0-368.el9.x86_64_1.ko",
-				"falco_centos_5.14.0-368.el9.x86_64_1.o",
+				"falco_centos_5.14.0-370.el9.x86_64_1.ko",
+				"falco_centos_5.14.0-370.el9.x86_64_1.o",
 			},
 			shouldCreate: true,
-			name:         "rebuild and publish 5.0.1+driver centos 5.14.0-368.el9.x86_64",
+			name:         "rebuild and publish 5.0.1+driver centos 5.14.0-370.el9.x86_64",
 		},
 	}
 

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 )
 
 var (
@@ -178,6 +179,9 @@ func dumpConfig(opts Options, dkYaml validate.DriverkitYaml) error {
 	}
 
 	dkYaml.Architecture = opts.Architecture.String()
+
+	// Sort kernelurls, so that we always get the same sorting for dbg configs.
+	slices.Sort(dkYaml.KernelUrls)
 
 	for _, driverVersion := range opts.DriverVersion {
 		dkYaml.FillOutputs(driverVersion, opts.Options)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

This way, we always get same sorting for headers.
It should help reduce the diff between daily test-infra dbg updates: https://github.com/falcosecurity/test-infra/pull/1273

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
